### PR TITLE
Fix SonarCloud build step

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,13 +42,16 @@ jobs:
   Analysis:
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
 
-      - name: Analyze with SonarCloud
+        - name: Build backend
+          run: mvn -B -f backend/pom.xml package
+
+        - name: Analyze with SonarCloud
 
         # You can pin the exact commit or the version.
         # uses: SonarSource/sonarcloud-github-action@v2.2.0
@@ -63,6 +66,7 @@ jobs:
             -Dsonar.projectKey=hashan-silva_nakshatra-one
             -Dsonar.organization=hashan-silva
             -Dsonar.scm.provider=git
+            -Dsonar.java.binaries=backend/target/classes
             # Comma-separated paths to directories containing main source files.
             #-Dsonar.sources= # optional, default is project base directory
             # Comma-separated paths to directories containing test source files.


### PR DESCRIPTION
## Summary
- build the backend before analysis so SonarCloud sees compiled classes
- pass Maven `target/classes` to sonar scanner

## Testing
- `mvn test -q` *(fails: could not resolve maven-resources-plugin)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d477608508324ab746be89e2e3147